### PR TITLE
Fix values with whitespace

### DIFF
--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -11,7 +11,7 @@ var fs = require('fs');
  */
 var regex = {
 	section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,
-	param: /^\s*([\w\.\-\_]+)\s*=\s*([^\s]*)\s*$/,
+	param: /^\s*([\w\.\-\_]+)\s*=\s*(.*?)\s*$/,
 	comment: /^\s*;.*$/
 };
 

--- a/test/files/test.ini
+++ b/test/files/test.ini
@@ -6,4 +6,5 @@ a.b=c
 
 [section2]
 ;test=worth
+there_is=a space in here with = and trailing tab	
 bar=foo

--- a/test/test.js
+++ b/test/test.js
@@ -56,5 +56,9 @@ module.exports = {
 	'look for a commented out variable': function(){
 		var config = iniparser.parseSync('./files/test.ini');
 		assert.equal(config.section2.test, null);
+	},
+	'variable with space in value': function(){
+		var config = iniparser.parseSync('./files/test.ini');
+		assert.equal(config.section2.there_is, "a space in here with = and trailing tab");
 	}
 };


### PR DESCRIPTION
Commit c93d3402f409139ff3871691abe389311b9dc938 introduce a bug (in 1.0.4): keys with a space in the value would not get parsed at all.

I've added a test case and a better non-greedy match.
