### PR TITLE
Line continuation via indentation

### DIFF
--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -39,6 +39,9 @@ module.exports.parseSync = function(file){
 };
 
 function parse(data){
+    // Line continuation, if a line starts with white space "\s" it will be appended to the previous line
+    data = data.replace(/((\r\n\s+)?|(\r\s+)?|(\n\s+)?)/mg,"");  //this regex combines lines that have leading white space
+
 	var value = {};
 	var lines = data.split(/\r\n|\r|\n/);
 	var section = null;


### PR DESCRIPTION
Not sure if this interest you but I added a small tweak to your iniparser.

Allows long blocks of text or arrays to be cleanly added to an ini file.
If a line begins with empty space (tab, space) it will automatically
be appended to the previous line.

! This assumes that section heads and keys are NOT indented. !

Example ini:

[SectionHead]
key1=value of key 1
my_array=val1,
         val2,
     val3
long_text=This is some long text
          that I need to include
      it wraps multiple lines.

The resulting object:

{SectionHead:
 {
  key1:'value of key 1',
  my_array:'val1, val2, val3',
  long_text:'This is some long text that I need to include it wraps multiple lines.'
 }
}
