### PR TITLE
Don't parse blank lines

### DIFF
--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -43,7 +43,7 @@ function parse(data){
 	var lines = data.split(/\r\n|\r|\n/);
 	var section = null;
 	lines.forEach(function(line){
-		if(regex.comment.test(line) && line.trim() == ''){
+		if(regex.comment.test(line) || line.trim() == ''){
 			return;
 		}else if(regex.param.test(line)){
 			var match = line.match(regex.param);

--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -43,7 +43,7 @@ function parse(data){
 	var lines = data.split(/\r\n|\r|\n/);
 	var section = null;
 	lines.forEach(function(line){
-		if(regex.comment.test(line)){
+		if(regex.comment.test(line) && line.trim() == ''){
 			return;
 		}else if(regex.param.test(line)){
 			var match = line.match(regex.param);


### PR DESCRIPTION
Don't parse blank lines. Useful to structure in a more clear way big ini files.
