### PR TITLE
Space as null value flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,42 @@ To parse a string in .ini format:
 var iniparser = require('iniparser');
 var config = iniparser.parseString('foo=bar');
 </pre>
+
+## Options
+The following options can be passed in as the second parameter to all 3 parse methods:
+
+treatEmptyStringsAsNull: Stores a setting as a null value if an empty string is detected as the value.
+
+
+To parse a .ini file async with options:
+<pre>
+var iniparser = require('iniparser');
+var options = {
+    treatEmptyStringsAsNull: true
+}
+iniparser.parse('./config.ini', options, function(err,data){
+	var version = data.version;
+});
+</pre>
+
+To parse a .ini file sync with options:
+<pre>
+var iniparser = require('iniparser');
+var options = {
+    treatEmptyStringsAsNull: true
+}
+var config = iniparser.parseSync('./config.ini', options);
+</pre>
+
+To parse a string in .ini format with options:
+<pre>
+var iniparser = require('iniparser');
+var options = {
+    treatEmptyStringsAsNull: true
+}
+var config = iniparser.parseString('foo=bar', options);
+</pre>
+
 ## Installation
 npm:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var config = iniparser.parseString('foo=bar');
 ## Options
 The following options can be passed in as the second parameter to all 3 parse methods:
 
-treatEmptyStringsAsNull: Stores a setting as a null value if an empty string is detected as the value.
+`treatEmptyStringsAsNull: boolean - Stores a setting as a null value if an empty string is detected as the value.`
 
 
 To parse a .ini file async with options:

--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -55,7 +55,7 @@ function parse(data, options){
         }else if(regex.param.test(line)){
             var match = line.match(regex.param);
             var lineValue =  match[2];
-            if(lineValue != null && parseOptions.treatEmptyStringsAsNull == true && !lineValue.trim()) {
+            if(lineValue != null && parseOptions.treatEmptyStringsAsNull === true && !lineValue.trim()) {
                 lineValue = null;
             }
             if(section){

--- a/lib/node-iniparser.js
+++ b/lib/node-iniparser.js
@@ -10,57 +10,68 @@ var fs = require('fs');
  * comment: ;this is a comment
  */
 var regex = {
-	section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,
-	param: /^\s*([\w\.\-\_]+)\s*=\s*(.*?)\s*$/,
-	comment: /^\s*;.*$/
+    section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,
+    param: /^\s*([\w\.\-\_]+)\s*=\s*(.*?)\s*$/,
+    comment: /^\s*;.*$/
 };
 
 /*
  * parses a .ini file
  * @param: {String} file, the location of the .ini file
+ * @param: {Object} options, the options to run the parse with
  * @param: {Function} callback, the function that will be called when parsing is done
  * @return: none
  */
-module.exports.parse = function(file, callback){
-	if(!callback){
-		return;
-	}
-	fs.readFile(file, 'utf8', function(err, data){
-		if(err){
-			callback(err);
-		}else{
-			callback(null, parse(data));
-		}
-	});
+module.exports.parse = function(file, options, callback){
+    if(typeof(options) == 'function' && !callback) {
+        //backwards compatibility with non-optioned method
+        callback = options;
+        options = null;
+    }
+    if(!callback){
+        return;
+    }
+    fs.readFile(file, 'utf8', function(err, data){
+        if(err){
+            callback(err);
+        }else{
+            callback(null, parse(data, options));
+        }
+    });
 };
 
-module.exports.parseSync = function(file){
-	return parse(fs.readFileSync(file, 'utf8'));
+module.exports.parseSync = function(file, options){
+    return parse(fs.readFileSync(file, 'utf8'), options);
 };
 
-function parse(data){
-	var value = {};
-	var lines = data.split(/\r\n|\r|\n/);
-	var section = null;
-	lines.forEach(function(line){
-		if(regex.comment.test(line)){
-			return;
-		}else if(regex.param.test(line)){
-			var match = line.match(regex.param);
-			if(section){
-				value[section][match[1]] = match[2];
-			}else{
-				value[match[1]] = match[2];
-			}
-		}else if(regex.section.test(line)){
-			var match = line.match(regex.section);
-			value[match[1]] = {};
-			section = match[1];
-		}else if(line.length == 0 && section){
-			section = null;
-		};
-	});
-	return value;
+function parse(data, options){
+    var parseOptions = options ? options : {};
+    var value = {};
+    var lines = data.split(/\r\n|\r|\n/);
+    var section = null;
+    lines.forEach(function(line){
+        if(regex.comment.test(line)){
+            return;
+        }else if(regex.param.test(line)){
+            var match = line.match(regex.param);
+            var lineValue =  match[2];
+            if(lineValue != null && parseOptions.treatEmptyStringsAsNull == true && !lineValue.trim()) {
+                lineValue = null;
+            }
+            if(section){
+                value[section][match[1]] = lineValue;
+            }else{
+                value[match[1]] = lineValue;
+            }
+        }else if(regex.section.test(line)){
+            var match = line.match(regex.section);
+            value[match[1]] = {};
+            section = match[1];
+        }else if(line.length == 0 && section){
+            section = null;
+        };
+    });
+    return value;
 }
 
 module.exports.parseString = parse;

--- a/test/files/test.ini
+++ b/test/files/test.ini
@@ -1,5 +1,6 @@
 foo=bar
 var_with_space_at_end = bar 
+var_with_empty_value =
 [worlds]
 earth=awesome
 a.b=c

--- a/test/test.js
+++ b/test/test.js
@@ -60,5 +60,11 @@ module.exports = {
 	'variable with space in value': function(){
 		var config = iniparser.parseSync('./files/test.ini');
 		assert.equal(config.section2.there_is, "a space in here with = and trailing tab");
-	}
+	},
+    'empty string as null option': function() {
+        var config = iniparser.parse('./files/test.ini', {treatEmptyStringsAsNull: true}, function(err, config) {
+            assert.equal(err, null);
+            assert.equal(config.var_with_empty_value, null);
+        });
+    }
 };


### PR DESCRIPTION
I needed slightly different behavior so I thought I would option-ize it. I've set up an additional "options" object parameter on the 3 parse methods (with backwards compatibility for iniparser.parse callback). Also updated readme and added test for the single new option: treatEmptyStringsAsNull, which will, as the name suggests, set the value of parameters that have no direct value (which come in as an empty string) to null.

For example:

``` ini
var_with_noValue=
```

Would come in when the flag is false (default) as:

``` javascript
{
     var_withNoValue: ''
}
```

and the same thing would come in when the flag is true as:

``` javascript
{
     var_withNoValue: null
}
```

It should be relatively easy to add new parameters in the future.
